### PR TITLE
 fix: Do not start pipewire in Display Manager user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pipewire (1.2.5-1deepin6) unstable; urgency=medium
+
+  *  fix: Do not start pipewire in Display Manager user.
+
+ -- zhaochengyi <zhaochengyi@uniontech.com>  Tue, 03 Dec 2024 11:26:12 +0800
+
 pipewire (1.2.5-1deepin5) unstable; urgency=medium
 
   * Feat: Supports mixing to mono.

--- a/debian/patches/Fix-Do-not-start-pipewire-in-Display-Manager-user.patch
+++ b/debian/patches/Fix-Do-not-start-pipewire-in-Display-Manager-user.patch
@@ -1,0 +1,67 @@
+From 2a25a9977d98e8b1eaab87ba01d287d030981fe8 Mon Sep 17 00:00:00 2001
+From: Chengyi Zhao <zhaochengyi@uniontech.com>
+Date: Tue, 3 Dec 2024 11:02:44 +0800
+Subject: [PATCH] fix: Do not start pipewire in Display Manager user
+
+---
+ src/daemon/systemd/user/pipewire-pulse.service.in | 2 ++
+ src/daemon/systemd/user/pipewire-pulse.socket     | 2 ++
+ src/daemon/systemd/user/pipewire.service.in       | 2 ++
+ src/daemon/systemd/user/pipewire.socket           | 2 ++
+ 4 files changed, 8 insertions(+)
+
+diff --git a/src/daemon/systemd/user/pipewire-pulse.service.in b/src/daemon/systemd/user/pipewire-pulse.service.in
+index 482f2e7..c020e00 100644
+--- a/src/daemon/systemd/user/pipewire-pulse.service.in
++++ b/src/daemon/systemd/user/pipewire-pulse.service.in
+@@ -15,6 +15,8 @@ Description=PipeWire PulseAudio
+ # socket-service relationship, see systemd.socket(5).
+ Requires=pipewire-pulse.socket
+ ConditionUser=!root
++ConditionUser=!lightdm
++ConditionUser=!dde
+ Wants=pipewire.service wireplumber.service pipewire-media-session.service
+ After=pipewire.service wireplumber.service pipewire-media-session.service
+ Conflicts=pulseaudio.service
+diff --git a/src/daemon/systemd/user/pipewire-pulse.socket b/src/daemon/systemd/user/pipewire-pulse.socket
+index 1ae5eda..0064542 100644
+--- a/src/daemon/systemd/user/pipewire-pulse.socket
++++ b/src/daemon/systemd/user/pipewire-pulse.socket
+@@ -1,6 +1,8 @@
+ [Unit]
+ Description=PipeWire PulseAudio
+ ConditionUser=!root
++ConditionUser=!lightdm
++ConditionUser=!dde
+ Conflicts=pulseaudio.socket
+ 
+ [Socket]
+diff --git a/src/daemon/systemd/user/pipewire.service.in b/src/daemon/systemd/user/pipewire.service.in
+index 4236c6b..638d772 100644
+--- a/src/daemon/systemd/user/pipewire.service.in
++++ b/src/daemon/systemd/user/pipewire.service.in
+@@ -15,6 +15,8 @@ Description=PipeWire Multimedia Service
+ # socket-service relationship, see systemd.socket(5).
+ Requires=pipewire.socket
+ ConditionUser=!root
++ConditionUser=!lightdm
++ConditionUser=!dde
+ 
+ [Service]
+ LockPersonality=yes
+diff --git a/src/daemon/systemd/user/pipewire.socket b/src/daemon/systemd/user/pipewire.socket
+index 890342a..a3bb012 100644
+--- a/src/daemon/systemd/user/pipewire.socket
++++ b/src/daemon/systemd/user/pipewire.socket
+@@ -1,6 +1,8 @@
+ [Unit]
+ Description=PipeWire Multimedia System Sockets
+ ConditionUser=!root
++ConditionUser=!lightdm
++ConditionUser=!dde
+ 
+ [Socket]
+ Priority=6
+-- 
+2.20.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 Don-t-automatically-start-pipewire-for-root-logins.patch
 Fix_services.patch
 Feat-Supports-mixing-to-MONO.patch
+Fix-Do-not-start-pipewire-in-Display-Manager-user.patch


### PR DESCRIPTION
Do not start pipewire in Display Manager user because it does not need to use audio processes.

lightdm user for Light Display Manager, and dde user for Deepin Display Manager.