### PR TITLE
manually add 1 dB to the minimum hardware volume

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pipewire (1.2.5-1deepin16) unstable; urgency=medium
+
+  * fix: Manually add 1 dB to the minimum hardware volume
+
+ -- qaqland <anguoli@uniontech.com>  Tue, 26 Aug 2025 19:21:14 +0800
+
 pipewire (1.2.5-1deepin15) unstable; urgency=medium
 
   * fix: Modify rtkit log from warn to debug(bug317451)

--- a/debian/patches/Fix-HW-MinMute.patch
+++ b/debian/patches/Fix-HW-MinMute.patch
@@ -1,0 +1,18 @@
+diff --git a/spa/plugins/alsa/acp/alsa-mixer.c b/spa/plugins/alsa/acp/alsa-mixer.c
+index 1f494ee0b5d73a0b0ef05cfcc259c76a5bf417a0..a31b8344f431e10a6d9ab3c8dd7b55dcc4671b88 100644
+--- a/spa/plugins/alsa/acp/alsa-mixer.c
++++ b/spa/plugins/alsa/acp/alsa-mixer.c
+@@ -1149,6 +1149,13 @@ static int element_set_volume(pa_alsa_element *e, snd_mixer_t *m, const pa_chann
+             if (e->volume_limit >= 0 && value > (e->max_dB * 100))
+                 value = (long) (e->max_dB * 100);
+ 
++            /* Some devices, especially USB sound cards, will automatically mute
++             * when set to min_dB. Therefore, a 1 dB increase is manually added
++             * here to prevent entering the volume dead zone */
++            if (value < (e->min_dB * 100 + 100)) {
++                value = (long) (e->min_dB * 100 + 100);
++            }
++
+             if (e->direction == PA_ALSA_DIRECTION_OUTPUT) {
+                 /* If we call set_playback_volume() without checking first
+                  * if the channel is available, ALSA behaves very

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@ Fix-Adapted-for-Unis-D3830-G3-sound-card.patch
 Fix-Optimize-the-volume-algorithm.patch
 Fix-Cancel-to-report-battery-level-of-HFP-AG.patch
 Fix-Modify-rtkit-log-from-warn-to-debug.patch
+Fix-HW-MinMute.patch


### PR DESCRIPTION
Some devices, especially USB sound cards, will automatically mute when set to min_dB. Therefore, a 1 dB increase is manually added here to prevent entering the volume dead zone.

Doing so is almost harmless, but it can prevent sudden loss of sound.