### PR TITLE
pulse-server: 修复设备端口变化时缺失订阅事件的问题

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pipewire (1.2.5-1deepin16) unstable; urgency=medium
+
+  * pulse-server: 修复设备端口变化时缺失订阅事件的问题
+
+ -- fuleyi <fuleyi@uniontech.com>  Tue, 04 Nov 2025 11:06:43 +0800
+
 pipewire (1.2.5-1deepin15) unstable; urgency=medium
 
   * fix: Modify rtkit log from warn to debug(bug317451)

--- a/debian/patches/Fix-Update-active-port-name-when-profile-changes.patch
+++ b/debian/patches/Fix-Update-active-port-name-when-profile-changes.patch
@@ -1,0 +1,68 @@
+Description: Fix missing subscription events on device port changes
+ When a device profile changes (e.g., Bluetooth headset switching from
+ a2dp-sink to headset-head-unit), the active port information changes
+ but PulseAudio compatibility layer clients don't receive the expected
+ PA_SUBSCRIPTION_EVENT_SOURCE or PA_SUBSCRIPTION_EVENT_SINK change events.
+ .
+ Root cause: The collect_device_info() function updates the active_port
+ index from SPA_PARAM_Route parameters, but doesn't update the corresponding
+ active_port_name field. When update_device_info() uses memcmp() to detect
+ changes in the device_info structure, it compares the entire structure
+ including active_port_name. If the pointer value doesn't change (even
+ though the actual port changed), no change is detected, and the change_mask
+ flag is not set, preventing subscription events from being sent.
+ .
+ Solution: After setting active_port in collect_device_info(), look up the
+ corresponding port name from SPA_PARAM_EnumRoute parameters by matching
+ both the port index and direction. Initialize active_port_name to NULL at
+ the start to ensure it's always recalculated.
+ .
+ This fix applies to all device types (Bluetooth, USB, PCI sound cards)
+ and all profile switching scenarios.
+Author: fuleyi <fuleyi@uniontech.com>
+Bug-Debian: https://bugs.debian.org/XXXXXX
+Forwarded: no
+Last-Update: 2025-10-30
+
+--- a/src/modules/module-protocol-pulse/collect.c
++++ b/src/modules/module-protocol-pulse/collect.c
+@@ -234,6 +234,8 @@ static void collect_device_info(struct
+ {
+ 	struct pw_manager_param *p;
+ 
++	dev_info->active_port_name = NULL;
++
+ 	if (card) {
+ 		spa_list_for_each(p, &card->param_list, link) {
+ 			uint32_t index, dev;
+@@ -256,6 +258,30 @@ static void collect_device_info(struct
+ 				dev_info->have_volume = true;
+ 			}
+ 		}
++
++		/* Look up the port name for the active port */
++		if (dev_info->active_port != SPA_ID_INVALID) {
++			spa_list_for_each(p, &card->param_list, link) {
++				uint32_t index, direction;
++				const char *name = NULL;
++
++				if (p->id != SPA_PARAM_EnumRoute)
++					continue;
++
++				if (spa_pod_parse_object(p->param,
++						SPA_TYPE_OBJECT_ParamRoute, NULL,
++						SPA_PARAM_ROUTE_index, SPA_POD_Int(&index),
++						SPA_PARAM_ROUTE_direction, SPA_POD_Id(&direction),
++						SPA_PARAM_ROUTE_name, SPA_POD_String(&name)) < 0)
++					continue;
++
++				if (index == dev_info->active_port &&
++				    direction == dev_info->direction) {
++					dev_info->active_port_name = name;
++					break;
++				}
++			}
++		}
+ 	}
+ 
+ 	spa_list_for_each(p, &device->param_list, link) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@ Fix-Adapted-for-Unis-D3830-G3-sound-card.patch
 Fix-Optimize-the-volume-algorithm.patch
 Fix-Cancel-to-report-battery-level-of-HFP-AG.patch
 Fix-Modify-rtkit-log-from-warn-to-debug.patch
+Fix-Update-active-port-name-when-profile-changes.patch


### PR DESCRIPTION
当设备配置文件发生变化时（例如蓝牙耳机从 a2dp-sink 切换到
headset-head-unit），活动端口信息会改变，但 PulseAudio 兼容层
客户端无法收到预期的 PA_SUBSCRIPTION_EVENT_SOURCE 或
PA_SUBSCRIPTION_EVENT_SINK 变化事件。

根本原因：
collect_device_info() 函数从 SPA_PARAM_Route 参数中更新了
active_port 索引，但没有更新对应的 active_port_name 字段。
当 update_device_info() 使用 memcmp() 检测 device_info 结构体 的变化时，会比较整个结构体包括 active_port_name。如果指针值
没有变化（即使实际端口已改变），则检测不到变化，导致 change_mask
标志（PW_MANAGER_OBJECT_FLAG_SOURCE/SINK）未被设置，从而
阻止了订阅事件的发送。

解决方案：
在 collect_device_info() 中设置 active_port 后，通过匹配端口
索引和方向，从 SPA_PARAM_EnumRoute 参数中查找对应的端口名称。
在函数开始时将 active_port_name 初始化为 NULL，确保每次都会
重新计算。

此修复适用于所有设备类型（蓝牙、USB、PCI 声卡）和所有配置文件
切换场景，确保使用 PulseAudio 兼容层的应用程序能够接收到正确的
设备变化通知。

测试场景：
- 蓝牙耳机配置文件切换（a2dp-sink ↔ headset-head-unit）
- 订阅 PA_SUBSCRIPTION_MASK_SOURCE/SINK 事件的应用程序
- 验证音频初始化无回归问题

修复问题：https://github.com/PipeWire/pipewire/issues/XXXXX