### PR TITLE
Added config for Hikvision XC-P514P-B 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pipewire (1.6.0-1deepin5) unstable; urgency=medium
+
+  * Add config to match hikvision
+
+ -- liujiahe <liujiahe@uniontech.com>  Thu, 19 Mar 2026 20:13:59 +0800
+
 pipewire (1.6.0-1deepin4) unstable; urgency=medium
 
   * Optimize the volume algorithm

--- a/debian/patches/Fix-add-config-to-hikvisionXC-P514P-B.patch
+++ b/debian/patches/Fix-add-config-to-hikvisionXC-P514P-B.patch
@@ -1,0 +1,192 @@
+Index: pipewire/spa/plugins/alsa/90-pipewire-alsa.rules
+===================================================================
+--- pipewire.orig/spa/plugins/alsa/90-pipewire-alsa.rules
++++ pipewire/spa/plugins/alsa/90-pipewire-alsa.rules
+@@ -204,6 +204,9 @@ ATTRS{idVendor}=="17aa", ATTRS{idProduct
+ # UNIS Unis D3830 G3
+ ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="4f18", ENV{ACP_PROFILE_SET}="unis-4f18-usb-audio.conf"
+ 
++# hikvision
++ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="4f36", ENV{ACP_PROFILE_SET}="hikvision-usb-audio.conf"
++
+ GOTO="pipewire_end"
+ 
+ LABEL="pipewire_check_pci"
+Index: pipewire/spa/plugins/alsa/mixer/paths/analog-input-front-mic-hikvision.conf
+===================================================================
+--- /dev/null
++++ pipewire/spa/plugins/alsa/mixer/paths/analog-input-front-mic-hikvision.conf
+@@ -0,0 +1,32 @@
++ This file is part of PulseAudio.
++#
++# PulseAudio is free software; you can redistribute it and/or modify
++# it under the terms of the GNU Lesser General Public License as
++# published by the Free Software Foundation; either version 2.1 of the
++# License, or (at your option) any later version.
++#
++# PulseAudio is distributed in the hope that it will be useful, but
++# WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++# General Public License for more details.
++#
++# You should have received a copy of the GNU Lesser General Public License
++# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
++
++; For devices where a 'Mic' or 'Mic Boost' element exists
++;
++; See analog-output.conf.common for an explanation on the directives
++
++[General]
++priority = 85
++description-key = analog-input-microphone-front
++
++[Jack Mic - Input,1]
++required-any = any
++
++[Element Mic,1]
++required-any = any
++switch = mute
++volume = merge
++override-map.1 = all
++override-map.2 = all-left,all-right
+Index: pipewire/spa/plugins/alsa/mixer/paths/analog-input-rear-mic-hikvision.conf
+===================================================================
+--- /dev/null
++++ pipewire/spa/plugins/alsa/mixer/paths/analog-input-rear-mic-hikvision.conf
+@@ -0,0 +1,36 @@
++# This file is part of PulseAudio.
++#
++# PulseAudio is free software; you can redistribute it and/or modify
++# it under the terms of the GNU Lesser General Public License as
++# published by the Free Software Foundation; either version 2.1 of the
++# License, or (at your option) any later version.
++#
++# PulseAudio is distributed in the hope that it will be useful, but
++# WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++# General Public License for more details.
++#
++# You should have received a copy of the GNU Lesser General Public License
++# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
++
++; For devices where a 'Mic' or 'Mic Boost' element exists
++;
++; See analog-output.conf.common for an explanation on the directives
++
++[General]
++priority = 87
++description-key = analog-input-microphone-rear
++
++[Jack Mic - Input]
++required-any = any
++
++[Jack Mic - Input,1]
++state.plugged = no
++state.unplugged = unknown
++
++[Element Mic]
++required-any = any
++switch = mute
++volume = merge
++override-map.1 = all
++override-map.2 = all-left,all-right
+Index: pipewire/spa/plugins/alsa/mixer/paths/analog-output-headphones-hikvision.conf
+===================================================================
+--- /dev/null
++++ pipewire/spa/plugins/alsa/mixer/paths/analog-output-headphones-hikvision.conf
+@@ -0,0 +1,38 @@
++# This file is part of PulseAudio.
++#
++# PulseAudio is free software; you can redistribute it and/or modify
++# it under the terms of the GNU Lesser General Public License as
++# published by the Free Software Foundation; either version 2.1 of the
++# License, or (at your option) any later version.
++#
++# PulseAudio is distributed in the hope that it will be useful, but
++# WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++# General Public License for more details.
++#
++# You should have received a copy of the GNU Lesser General Public License
++# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
++
++; Path for mixers that have a 'Headphone' control
++;
++; See analog-output.conf.common for an explanation on the directives
++
++[General]
++priority = 99
++description-key = analog-output-headphones
++
++[Properties]
++device.icon_name = audio-headphones
++
++[Jack Headphone - Output]
++required-any = any
++
++[Element PCM,1]
++switch = mute
++volume = merge
++override-map.1 = all
++override-map.2 = all-left,all-right
++
++[Element PCM]
++switch = off
++volume = off
+Index: pipewire/spa/plugins/alsa/mixer/profile-sets/hikvision-usb-audio.conf
+===================================================================
+--- /dev/null
++++ pipewire/spa/plugins/alsa/mixer/profile-sets/hikvision-usb-audio.conf
+@@ -0,0 +1,52 @@
++# This file is part of PulseAudio.
++#
++# PulseAudio is free software; you can redistribute it and/or modify
++# it under the terms of the GNU Lesser General Public License as
++# published by the Free Software Foundation; either version 2.1 of the
++# License, or (at your option) any later version.
++#
++# PulseAudio is distributed in the hope that it will be useful, but
++# WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++# General Public License for more details.
++#
++# You should have received a copy of the GNU Lesser General Public License
++# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
++
++[General]
++auto-profiles = yes
++
++[Mapping analog-stereo-headphone]
++description = Front Headphone
++paths-output = analog-output-headphones-hikvision
++device-strings = hw:%f,1
++channel-map = left,right
++direction = output
++
++[Mapping analog-stereo-speaker]
++description = Rear Speaker
++paths-output = analog-output-speaker
++device-strings = hw:%f,0
++channel-map = left,right
++direction = output
++
++[Mapping analog-front-mic]
++description = Front Microphone
++paths-input = analog-input-front-mic-hikvision
++device-strings = hw:%f,2
++channel-map = left,right
++direction = input
++
++[Mapping analog-rear-mic]
++description = Rear Microphone
++paths-input = analog-input-rear-mic-hikvision
++device-strings = hw:%f,0
++channel-map = left,right
++direction = input
++
++[Mapping analog-linein]
++description = Linein
++paths-input = analog-input-linein
++device-strings = hw:%f,1
++channel-map = left,right
++direction = input

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,4 +4,4 @@ Fix-Adapted-for-Unis-D3830-G3-sound-card.patch
 Fix-Modify-rtkit-log-from-warn-to-debug.patch
 Fix-Cancel-to-report-battery-level-of-HFP-AG.patch
 Fix-Optimize-the-volume-algorithm.patch
-
+Fix-add-config-to-hikvisionXC-P514P-B.patch


### PR DESCRIPTION
Added udev rule to match Hikvision USB audio device (VID:0bda PID:4f36) Created custom mixer path configurations for front/rear microphone inputs Created headphone output path configuration for the device Created profile set mapping for headphone, speaker, and microphone channels

Log: Added audio configuration support for Hikvision XC-P514P-B device

Influence:

Verify audio device detection with udev rules
Test front and rear microphone input functionality Confirm headphone and speaker output routing works correctly Validate all audio profile mappings (headphone, speaker, mic, line-in)

feat(audio): 为海康威视 XC-P514P-B USB音频设备添加配置支持

在udev规则中添加海康威视USB音频设备匹配规则 (VID:0bda PID:4f36)
创建前置/后置麦克风输入的自定义混音器路径配置
创建设备专用的耳机输出路径配置
创建音频配置文件映射耳机、扬声器和麦克风通道

Log: 新增海康威视 XC-P514P-B 设备音频配置支持

Influence:

验证udev规则正确检测音频设备
测试前置和后置麦克风输入功能
确认耳机和扬声器输出路由正常工作
验证所有音频配置文件映射（耳机、扬声器、麦克风、线路输入）

pms: https://pms.uniontech.com/bug-view-352509.html