### PR TITLE
fix: Remove conflict between pipewire-alsa and pulseaudio

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
+pipewire (1.6.0-1deepin9) unstable; urgency=medium
+
+  * Remove the conflict between pipewire-alsa and pulseaudio
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 21 Apr 2026 17:35:25 +0800
+
 pipewire (1.6.0-1deepin8) unstable; urgency=medium
 
   * Backport critical security and stability fixes to 1.6.0
-
   * This backports 8 essential fixes from upstream (1.6.x/1.7.0) addressing
   * memory safety, resource management, and systemd integration:
 
@@ -18,6 +23,7 @@ pipewire (1.6.0-1deepin8) unstable; urgency=medium
   * Fixes: #5159, #5176, #5202, #5140 and related stability issues.
 
  -- zhaochengyi <zhaochengyi@uniontech.com>  Fri, 17 Apr 2026 14:37:13 +0800
+
 
 pipewire (1.6.0-1deepin7) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -303,7 +303,7 @@ Architecture: any
 Multi-Arch: same
 Replaces: pipewire-audio-client-libraries (<< 0.3.54-1~)
 Breaks: pipewire-audio-client-libraries (<< 0.3.54-1~)
-Conflicts: pulseaudio
+# Conflicts: pulseaudio
 Depends: pipewire (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
They can coexist, only config priority is affected