### PR TITLE
fix: Use absolute LADSPA plugin path to prevent LADSPA_PATH hijacking

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pipewire (1.6.4-1deepin12) unstable; urgency=medium
+
+  * Use absolute LADSPA plugin path to prevent LADSPA_PATH hijacking.
+
+ -- Chengyi Zhao <zhaochengyi@uniontech.com>  Fri, 26 Jun 2026 15:34:34 +0800
+
 pipewire (1.6.4-1deepin11) unstable; urgency=medium
 
   *  Add rnnoise source config for noise-suppression-for-voice.

--- a/debian/control
+++ b/debian/control
@@ -252,6 +252,7 @@ Section: video
 Architecture: any
 Multi-Arch: foreign
 Depends: libpipewire-0.3-modules (= ${binary:Version}),
+	 rnnoise-plugin-ladspa (>= 1.10-0deepin1),
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: dbus-user-session,

--- a/debian/patches/Fix-Use-absolute-LADSPA-plugin-path.patch
+++ b/debian/patches/Fix-Use-absolute-LADSPA-plugin-path.patch
@@ -1,0 +1,35 @@
+From 17e6e6285cd008e22144f8f75b6676b9a0567160 Mon Sep 17 00:00:00 2001
+From: Chengyi Zhao <zhaochengyi@uniontech.com>
+Date: Fri, 26 Jun 2026 14:24:59 +0800
+Subject: [PATCH] fix: Use absolute LADSPA plugin path to prevent LADSPA_PATH
+ hijacking
+
+---
+ src/daemon/filter-chain.conf.d/source-rnnoise.conf | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/daemon/filter-chain.conf.d/source-rnnoise.conf b/src/daemon/filter-chain.conf.d/source-rnnoise.conf
+index ec864f0..f299075 100644
+--- a/src/daemon/filter-chain.conf.d/source-rnnoise.conf
++++ b/src/daemon/filter-chain.conf.d/source-rnnoise.conf
+@@ -16,14 +16,9 @@ context.modules = [
+                     {
+                         type   = ladspa
+                         name   = rnnoise
+-			# The path to the plugin. The suffix .so is appended to
+-			# this string and then the file is then located in the directories
+-			# listed in the environment variable LADSPA_PATH or
+-			# /usr/lib64/ladspa, /usr/lib/ladspa or the system library directory
+-			# as a fallback.
+-			# You might want to use an absolute path here to avoid problems.
+-                        plugin = "librnnoise_ladspa"
+-                        label  = noise_suppressor_stereo
++			# Absolute path prevents shared library hijacking via LADSPA_PATH
++                        plugin = "/usr/lib/ladspa/librnnoise_ladspa.so"
++                        label  = noise_suppressor_mono
+                         control = {
+ 			    "VAD Threshold (%)"       = 60.0   # Increase to 60–80 to reduce false triggers and prevent repeated toggling of noise segments
+ 			    "VAD Grace Period (ms)"   = 300    # Extend to 300–500 for smoother noise decay and less abrupt silence insertion
+-- 
+2.20.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@ Tmp-Add-Lenovo-M90H-G1S.patch
 Fix-Set-profile-to-off-when-connecting-to-peer-BT-PC.patch
 Fix-Skip-audio-formats-before-S16.patch
 Feat-Add-rnnoise-source-config-for-noise-suppression.patch
+Fix-Use-absolute-LADSPA-plugin-path.patch


### PR DESCRIPTION
Switch from a relative plugin name to an absolute path, eliminating the risk of loading a malicious library via the environment variable. The label is also updated to mono for correctness.

Task: 390325